### PR TITLE
Configure custom user data using realm-cli

### DIFF
--- a/users_permissions/README.md
+++ b/users_permissions/README.md
@@ -55,14 +55,7 @@ For the purpose of this demo you have to create your own Atlas App Service. Foll
 Then run this command:
 
     `realm-cli push --yes`
-1. Then go to the UI and manually allow `Custom User Data` in **Authentication**. Select the following fields:
-    ```json
-    "mongo_service_name": "mongodb-atlas",
-    "database_name": "users_permissions",
-    "collection_name": "Role",
-    "user_id_field": "owner_id"
-    ```
-    Read [this page](https://www.mongodb.com/docs/atlas/app-services/users/enable-custom-user-data/) for more information about enabling custom user data.
+
 1. Create a new user for administrator.
 
     `realm-cli users create  --app users_permissions --type email --email <username or email> --password <password>`

--- a/users_permissions/assets/atlas_app/auth/custom_user_data.json
+++ b/users_permissions/assets/atlas_app/auth/custom_user_data.json
@@ -1,3 +1,7 @@
 {
-    "enabled": false
+    "enabled": true,
+    "mongo_service_name": "mongodb-atlas",
+    "database_name": "users_permissions",
+    "collection_name": "Role",
+    "user_id_field": "owner_id"
 }


### PR DESCRIPTION
After fixing https://jira.mongodb.org/browse/BAAS-19835 it is already possible to add custom user data configuration from json file.