### PR TITLE
Deprecate `flutter pub run` command

### DIFF
--- a/.github/workflows/ci.sh
+++ b/.github/workflows/ci.sh
@@ -11,7 +11,7 @@ where:
     --get
         get all dependencies
     --install
-        install realm_dart package
+        install realm/realm_dart package
     --generate
         generate realm models
     --run
@@ -63,8 +63,8 @@ runInstall() {
         printf "\ndart run realm_dart install\n"
         dart run realm_dart install
     else
-        printf "\nflutter pub run realm install\n"
-        flutter pub run realm install
+        printf "\ndart run realm install\n"
+        dart run realm install
     fi
 }
 
@@ -75,8 +75,8 @@ runGenerate() {
         dart run realm_dart generate
     else if grep -q 'realm:' "pubspec.yaml";
         then
-            printf "\nflutter pub run realm generate\n"
-            flutter pub run realm generate
+            printf "\ndart run realm generate\n"
+            dart run realm generate
         fi
     fi
 }

--- a/users_permissions/README.md
+++ b/users_permissions/README.md
@@ -147,9 +147,9 @@ in [MongoDB Atlas](https://www.mongodb.com/docs/atlas) for more advanced and sec
 
 * For creating an administrator with full permissions run these commands:
 
-    `flutter pub run realm install`
+    `dart run realm install`
 
-    `flutter pub run lib/cli/run create-admin --username <admin user name> --password <admin password>`
+    `dart run lib/cli/run.dart create-admin --username <admin user name> --password <admin password>`
 
 ### Browse the collection in Atlas
 
@@ -160,4 +160,4 @@ in [MongoDB Atlas](https://www.mongodb.com/docs/atlas) for more advanced and sec
     1. See in this document how to [browse the collections in Atlas](https://www.mongodb.com/docs/atlas/atlas-ui/collections/#view-collections).
 
 
-##### The "Dart" name and logo and the "Flutter" name and logo are trademarks owned by Google. 
+##### The "Dart" name and logo and the "Flutter" name and logo are trademarks owned by Google.

--- a/users_permissions/lib/cli/run.dart
+++ b/users_permissions/lib/cli/run.dart
@@ -5,7 +5,7 @@ import 'package:flutter_todo/cli/create_admin_cmd.dart';
 void main(List<String> arguments) async {
   if (arguments.isNotEmpty) {
     print(arguments.join(","));
-    CommandRunner<void>("flutter pub run", 'Helper commands for running samples.')
+    CommandRunner<void>("dart run", 'Helper commands for running samples.')
       ..addCommand(CreateAdminUserCommand())
       ..run(arguments).then((value) => exit(0)).catchError((Object error) {
         if (error is UsageException) {

--- a/users_permissions/lib/components/app_bar.dart
+++ b/users_permissions/lib/components/app_bar.dart
@@ -5,8 +5,8 @@ import 'package:flutter_todo/realm/app_services.dart';
 import 'package:provider/provider.dart';
 import 'package:flutter_todo/realm/realm_services.dart';
 
-class TodoAppBar extends StatelessWidget with PreferredSizeWidget {
-  TodoAppBar({Key? key}) : super(key: key);
+class TodoAppBar extends StatelessWidget implements PreferredSizeWidget {
+  const TodoAppBar({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
Command `flutter pub run` is deprecated

- updated ReadMe files.

- updated CI commands.

`PreferredSizeWidget` is not a Mixin.
Check the supported versions in the ReadMe files.