### PR TITLE
Update new_release.yml to use `GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/new_release.yml
+++ b/.github/workflows/new_release.yml
@@ -45,4 +45,4 @@ jobs:
           draft: false
           body: An automated PR for released realm version.
           commit-message: Update samples with realm ${{ inputs.version }}
-          token: ${{ secrets.REALM_CI_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `REALM_CI_PAT` is broken, due to SSO.